### PR TITLE
Added silent mode and native i3 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,162 @@
 version = 3
 
 [[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "cc"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+
+[[package]]
+name = "clap"
+version = "4.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d7ae14b20b94cb02149ed21a86c423859cbe18dc7ed69845cace50e52b40a5"
+dependencies = [
+ "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "is-terminal",
+ "once_cell",
+ "strsim",
+ "termcolor",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44bec8e5c9d09e439c4335b1af0abaab56dcf3b94999a936e1bb47b9134288f0"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "350b9cf31731f9957399229e9b2adc51eeabdfbe9d71d9a0552275fd12710d09"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfa919a82ea574332e2de6e74b4c36e74d41982b335080fa59d4ef31be20fdf3"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857"
+dependencies = [
+ "hermit-abi",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+
+[[package]]
+name = "libc"
+version = "0.2.139"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+
+[[package]]
+name = "once_cell"
+version = "1.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+
+[[package]]
+name = "os_str_bytes"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -24,6 +176,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rustix"
+version = "0.36.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd5c6ff11fecd55b40746d1995a02f2eb375bf8c00d192d521ee09f42bef37bc"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
@@ -61,6 +227,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -72,9 +244,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "tuilade"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "serde",
  "serde_derive",
  "serde_json",
@@ -85,3 +267,106 @@ name = "unicode-ident"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ description = "A command line utility to parse the output of `i3-save-tree` and 
 serde_json = "1.0.93"
 serde = "1.0.152"
 serde_derive = "1.0.152"
+clap = { version = "4.1.8", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ cargo install --path .
 
 Then you can create a small script to simplify editing of the command in the
 [Usage](#usage) section, for example in your `.config/i3` directory, possibly
-running `tuilade` in `silent` mode:
+running `tuilade` in `silent` and `no-swallows` mode:
 
 ```sh
 #!/bin/sh
 
-i3-msg -t get_tree | $HOME/.cargo/bin/tuilade -s | dot -Tpng | feh --class fehi3tuilade -
+i3-msg -t get_tree | $HOME/.cargo/bin/tuilade -s -n | dot -Tpng | feh --class fehi3tuilade -
 ```
 
 Finally, you can add a binding to show the tree (in this example, `$mod+t`) and
@@ -53,6 +53,7 @@ Usage: tuilade [OPTIONS]
 
 Options:
   -s, --silent   If enabled, will hide empty sections at best
+  -n, --no-swallows  If enabled, will hide swallows
   -h, --help     Print help
   -V, --version  Print version
 ```

--- a/README.md
+++ b/README.md
@@ -8,13 +8,56 @@ Simply clone the repository and compile with `cargo` (or `cargo install`).
 
 ## Usage
 
-In order to do some pre-parsing, use the following one-liner, where `<n>` is the
-number of the targeted workspace:
+You'll need to extract the i3 tree and pipe it to Tuilade:
 
 ```bash
-i3-save-tree --workspace=<n> | sed "s/^\(\s*\)\/\/ \"/\1  \"/" | grep -v "^\s*//" | cargo run | dot -Tpng
+i3-msg -t get_tree | cargo run | dot -Tpng
 ```
 
 Of course, you can change the `-Tpng` to any of the output formats supported by
 `dot`. You can then pipe/save the output from `idot`/`dot` and visualized it
 however you want as well.
+
+### Display in a floating window
+
+First, install `tuilade` to your path by running `cargo install` in `tuilade`'s
+directory:
+
+```bash
+cargo install --path .
+```
+
+Then you can create a small script to simplify editing of the command in the
+[Usage](#usage) section, for example in your `.config/i3` directory, possibly
+running `tuilade` in `silent` mode:
+
+```sh
+#!/bin/sh
+
+i3-msg -t get_tree | $HOME/.cargo/bin/tuilade -s | dot -Tpng | feh --class fehi3tuilade -
+```
+
+Finally, you can add a binding to show the tree (in this example, `$mod+t`) and
+set the window to floating mode:
+
+```
+for_window [class="^fehi3tuilade$"] floating enable
+
+bindsym $mod+t exec $HOME/.config/i3/tuilade.sh
+```
+
+### Available options
+
+```
+Usage: tuilade [OPTIONS]
+
+Options:
+  -s, --silent   If enabled, will hide empty sections at best
+  -h, --help     Print help
+  -V, --version  Print version
+```
+
+#### Silent mode
+
+Silent mode (`-s` or `--silent`) will try to hide empty or default sections.
+

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Usage: tuilade [OPTIONS]
 Options:
   -s, --silent   If enabled, will hide empty sections at best
   -n, --no-swallows  If enabled, will hide swallows
+  -e, --expand-from <EXPAND_FROM>  Expand tree from a given level [default: workspace] [possible values: root, output, workspace, dock-area, con, floating-con]
+  -p, --print-parents              Show the parents in the tree
   -h, --help     Print help
   -V, --version  Print version
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -147,7 +147,7 @@ impl TryFrom<&Value> for TreeType {
         let st = utils::try_string(val)?;
         match st {
             "con" => Ok(Self::Con),
-            _ => Err(String::from("Unknown tree type \"{st}\"")),
+            _ => Err(format!("Unknown tree type \"{st}\"")),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -395,22 +395,35 @@ impl Node {
         // | Border Type          |         |           |          |
         // +--------------------------------+----------------------+
 
+        // Will cut text after this number of characters
+        const CUT_AT: usize = 50;
+
         // Build the label
         let default = "(no name)".to_owned();
 
-        let name = self.name.as_ref().unwrap_or(&default);
-        let (all_name, _) = name.split_at(std::cmp::min(50, name.len()));
+        let name = self.name.as_ref().unwrap_or(&default).chars();
+
+        let cut_name = if name.clone().count() > CUT_AT {
+            name.take(CUT_AT)
+                .map(|c| match c {
+                    '\\' => "\\\\".to_owned(),
+                    '\"' => "\\\"".to_owned(),
+                    '|' => "\\|".to_owned(),
+                    '^' => "\\^".to_owned(),
+                    '/' => "\\/".to_owned(),
+                    '<' => "&lt;".to_owned(),
+                    '>' => "&gt;".to_owned(),
+                    e => e.to_string(),
+                })
+                .collect::<String>()
+                + "..."
+        } else {
+            name.collect::<String>()
+        };
+        // .split_at(std::cmp::min(50, name.len()));
 
         let label = if settings.silent {
-            format!("{{<NAME>{name}|{{ {{ {{ Tree Type:\\n{tree_type} | Floating:\\n{floating} }} | Border Type:\\n{border_type} | {lygeom} }}| {{ {{ Percent:\\n{percent:0.3}% {cbwidth} }} {sm} }} }} }}",
-            name = all_name
-                .replace('\\', "\\\\")
-                .replace('\"', "\\\"")
-                .replace('|', "\\|")
-                .replace('^', "\\^")
-                .replace('/', "\\/")
-                .replace('<', "&lt;")
-                .replace('>', "&gt;") + if all_name.len() < name.len() { " [...]" } else { "" },
+            name = cut_name,
             tree_type = self.tree_type.to_string(),
             floating = self.floating.to_string(),
             border_type = self.border.to_string(),
@@ -439,16 +452,7 @@ impl Node {
             }
         )
         } else {
-            format!("{{<NAME>{name}|{{ {{ {{ Tree Type:\\n{tree_type} | Floating:\\n{floating} }} | Border Type:\\n{border_type} | {lygeom} }}| {{ {{ Percent:\\n{percent:0.3}% | Border Width:\\n{cbwidth} }} | {{ {swallows} | {marks} }} }} }} }}",
-            name = self.name.as_ref()
-                .unwrap_or(&default)
-                .replace('\\', "\\\\")
-                .replace('\"', "\\\"")
-                .replace('|', "\\|")
-                .replace('^', "\\^")
-                .replace('/', "\\/")
-                .replace('<', "&lt;")
-                .replace('>', "&gt;") + if all_name.len() < name.len() { " [...]" } else { "" },
+            name = cut_name,
             tree_type = self.tree_type.to_string(),
             floating = self.floating.to_string(),
             border_type = self.border.to_string(),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -23,6 +23,13 @@ pub fn try_f64(val: &Value) -> Result<f64, String> {
     }
 }
 
+pub fn try_bool(val: &Value) -> Result<&bool, String> {
+    match val {
+        Value::Bool(b) => Ok(b),
+        _ => Err(String::from("Invalid JSON Value type (expected boolean)")),
+    }
+}
+
 pub fn try_i64(val: &Value) -> Result<i64, String> {
     let num = try_number(val)?;
     if num.is_i64() {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -23,6 +23,15 @@ pub fn try_f64(val: &Value) -> Result<f64, String> {
     }
 }
 
+pub fn try_i64(val: &Value) -> Result<i64, String> {
+    let num = try_number(val)?;
+    if num.is_i64() {
+        Ok(num.as_i64().unwrap())
+    } else {
+        Err(String::from("Invalid JSON number: Expected a i64"))
+    }
+}
+
 pub fn try_u64(val: &Value) -> Result<u64, String> {
     let num = try_number(val)?;
     if num.is_u64() {


### PR DESCRIPTION
- `tuilade` won't require `i3-save-tree` as an input anymore and can now be directly used with `i3msg -t get_tree`
- Added silent mode (`-s`): will hide non needed information
- Added no-swallows mode (`-n`): will hide swallow nodes
- Added beginning of full tree printing (`-e`)
- Added whether to print parents of the beginning of the full tree print (`-p`)